### PR TITLE
Ensure videos autoplay on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
 
 <body>
   <!-- 背景動画 -->
-  <video autoplay loop muted playsinline class="video-background" aria-label="背景動画" title="背景動画" poster="bg_poster.jpg">
+  <video autoplay loop muted playsinline preload="auto" class="video-background" aria-label="背景動画" title="背景動画" poster="bg_poster.jpg">
     <source src="bg.webm" type="video/webm">
   <source src="bg.mp4" type="video/mp4">
     Your browser does not support the video tag.
@@ -220,5 +220,26 @@
 
   <!-- フッター -->
   <div class="footer">© テイテンメイ 2025</div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var video = document.querySelector('.video-background');
+      if (video) {
+        video.muted = true;
+        var playPromise = video.play();
+        if (playPromise !== undefined) {
+          playPromise.catch(function() {
+            var attemptPlay = function() {
+              video.play();
+              document.removeEventListener('touchstart', attemptPlay);
+              document.removeEventListener('click', attemptPlay);
+            };
+            document.addEventListener('touchstart', attemptPlay, { once: true });
+            document.addEventListener('click', attemptPlay, { once: true });
+          });
+        }
+      }
+    });
+  </script>
 </body>
 </html>

--- a/omoi_section.html
+++ b/omoi_section.html
@@ -334,7 +334,7 @@
 
 <!-- Section 1 -->
 <section>
-  <video class="bg-video" autoplay muted loop playsinline poster="video_poster.jpg">
+  <video class="bg-video" autoplay muted loop playsinline preload="auto" poster="video_poster.jpg">
     <source src="old_film.webp" type="video/webm">
   <source src="old_film.mp4" type="video/mp4">
     お使いのブラウザは動画に対応していません。
@@ -515,6 +515,27 @@
   
   eggModal.addEventListener('click', (e) => {
     if (e.target.id === 'closeEgg' || e.target === eggModal) hideEggModal();
+  });
+</script>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var video = document.querySelector('.bg-video');
+    if (video) {
+      video.muted = true;
+      var playPromise = video.play();
+      if (playPromise !== undefined) {
+        playPromise.catch(function() {
+          var attemptPlay = function() {
+            video.play();
+            document.removeEventListener('touchstart', attemptPlay);
+            document.removeEventListener('click', attemptPlay);
+          };
+          document.addEventListener('touchstart', attemptPlay, { once: true });
+          document.addEventListener('click', attemptPlay, { once: true });
+        });
+      }
+    }
   });
 </script>
 


### PR DESCRIPTION
## Summary
- keep videos muted and preload them for autoplay
- add a JavaScript helper that forces play on page load and retries after first user interaction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887340bd724832a88d6501a0ff1f4dc