### PR TITLE
Adjust final section styles

### DIFF
--- a/css/omoi_section.css
+++ b/css/omoi_section.css
@@ -61,10 +61,14 @@
 
     /* 新しい最終セクションのスタイル */
     .section-final {
-      background-color: #1c1c1e;
+      height: 35vh;
+      min-height: 35vh;
+      background: linear-gradient(to bottom, rgba(28, 28, 30, 0.0), #1c1c1e);
       color: #ffffff;
-      height: auto;
-      padding-bottom: 5rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
     }
 
     .text-dark {


### PR DESCRIPTION
## Summary
- tweak `.section-final` to occupy only a portion of viewport
- use a gradient background for a softer transition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887559e410c832a8843846c9ddbba5b