### PR TITLE
Optimize mobile layout for final thoughts sections

### DIFF
--- a/css/omoi_section.css
+++ b/css/omoi_section.css
@@ -8,10 +8,13 @@
       font-family: 'Noto Sans JP', sans-serif;
       scroll-behavior: smooth;
       background-color: #000;
+      height: 100%;
+      scroll-snap-type: y mandatory;
     }
 
     section {
       min-height: 100vh;
+      scroll-snap-align: start;
       position: relative;
       display: flex;
       justify-content: center;
@@ -177,8 +180,8 @@
 
     @media (max-width: 600px) {
       section {
-        min-height: auto;
-        height: auto;
+        min-height: 100vh;
+        height: 100vh;
         padding: 3rem 1rem;
       }
       .text-content {
@@ -196,8 +199,8 @@
         gap: 1.2rem;
       }
       .section-final {
-        height: auto;
-        min-height: auto;
+        height: 100vh;
+        min-height: 100vh;
         padding-bottom: 5rem;
       }
     }


### PR DESCRIPTION
## Summary
- snap each section to full screen height on mobile
- use scroll snapping so only one section shows at a time

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68875cefe560832a993339792d5486b9