### PR TITLE
Align hub and vista detail layouts

### DIFF
--- a/css/hub_detail.css
+++ b/css/hub_detail.css
@@ -1,46 +1,55 @@
 
 body {
   font-family: 'Noto Sans JP', sans-serif;
+  background-color: #111;
+  color: #eee;
   margin: 0;
-  padding: 0;
+  padding: 40px 20px;
   line-height: 1.8;
-  background: #000; /* 黑色背景 */
-  color: #f5f5f5;   /* 主体文字浅灰白 */
 }
 
 .container {
-  max-width: 1200px;
+  max-width: 960px;
   margin: auto;
-  padding: 0 20px;
 }
 
 .section {
-  padding: 60px 10%;
-  margin: 0 auto;
-  max-width: 1100px;
+  margin-bottom: 3em;
 }
 
-h1, h2 {
+h1 {
+  font-size: 2.6em;
+  margin-bottom: 0.2em;
+  color: #fff;
+}
+
+h2 {
   text-align: center;
-  margin-bottom: 1em;
-  color: #ffffff;
+  margin-bottom: 0.6em;
+  color: #f0f0f0;
 }
 
 .subheading {
   text-align: center;
-  font-size: 1.1rem;
+  font-size: 1.2em;
   color: #ccc;
-  margin-top: -10px;
-  margin-bottom: 40px;
+  margin-bottom: 2em;
 }
 
 .gallery-img {
-  max-width: 100%;
+  max-width: 720px;
+  width: 100%;
   height: auto;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.3s ease;
   display: block;
-  margin: 20px auto;
-  border-radius: 8px;
+  margin: 0 auto;
   box-shadow: 0 6px 18px rgba(255,255,255,0.1);
+}
+
+.gallery-img:hover {
+  transform: scale(1.02);
 }
 
 .caption, .img-caption {
@@ -65,6 +74,34 @@ h1, h2 {
   box-shadow: 0 6px 18px rgba(255, 255, 255, 0.1);
 }
 
+/* === Lightbox === */
+.lightbox {
+  opacity: 0;
+  transition: opacity 0.35s;
+  display: none;
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  justify-content: center;
+  align-items: center;
+}
+
+.lightbox.active {
+  display: flex;
+  opacity: 1;
+}
+
+.lightbox img {
+  max-width: 90%;
+  max-height: 90%;
+  border-radius: 12px;
+  box-shadow: 0 0 30px rgba(0,0,0,0.4);
+}
+
 /* === 返回按钮导航 === */
 nav.back {
   margin-top: 4em;
@@ -73,7 +110,7 @@ nav.back {
 
 footer {
   text-align: center;
-  margin: 80px 0 20px;
+  margin-top: 60px;
   font-size: 0.85rem;
   color: #777;
 }

--- a/css/vista_detail.css
+++ b/css/vista_detail.css
@@ -42,7 +42,7 @@ h1 {
 }
 
 /* === 图片设定（项目图） === */
-.gallery img {
+.gallery-img {
   max-width: 720px;
   width: 100%;
   height: auto;
@@ -53,7 +53,7 @@ h1 {
   margin: 0 auto;
 }
 
-.gallery img:hover {
+.gallery-img:hover {
   transform: scale(1.02);
 }
 
@@ -151,7 +151,7 @@ footer {
     line-height: 1.7;
   }
 
-  .gallery img,
+  .gallery-img,
   .award {
     max-width: 95%;
   }

--- a/js/hub_detail.js
+++ b/js/hub_detail.js
@@ -1,11 +1,11 @@
 
-document.addEventListener("DOMContentLoaded", () => {
-  const sections = document.querySelectorAll(".section");
+document.addEventListener('DOMContentLoaded', () => {
+  const sections = document.querySelectorAll('.section');
 
   const observer = new IntersectionObserver((entries) => {
     entries.forEach(entry => {
       if (entry.isIntersecting) {
-        entry.target.classList.add("fade-in");
+        entry.target.classList.add('fade-in');
         observer.unobserve(entry.target);
       }
     });
@@ -15,5 +15,28 @@ document.addEventListener("DOMContentLoaded", () => {
 
   sections.forEach(section => {
     observer.observe(section);
+  });
+
+  const lightbox = document.getElementById('lightbox');
+  const lightboxImg = lightbox.querySelector('img');
+  const galleryImages = document.querySelectorAll('.gallery-img');
+
+  galleryImages.forEach(img => {
+    img.addEventListener('click', () => {
+      lightboxImg.src = img.src;
+      lightbox.classList.add('active');
+    });
+  });
+
+  lightbox.addEventListener('click', () => {
+    lightbox.classList.remove('active');
+    lightboxImg.src = '';
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (lightbox.classList.contains('active') && e.key === 'Escape') {
+      lightbox.classList.remove('active');
+      lightboxImg.src = '';
+    }
   });
 });

--- a/js/vista_detail.js
+++ b/js/vista_detail.js
@@ -1,24 +1,40 @@
-    document.addEventListener('DOMContentLoaded', () => {
-      const lightbox = document.getElementById('lightbox');
-      const lightboxImg = lightbox.querySelector('img');
-      const galleryImages = document.querySelectorAll('.gallery-img');
+document.addEventListener('DOMContentLoaded', () => {
+  const lightbox = document.getElementById('lightbox');
+  const lightboxImg = lightbox.querySelector('img');
+  const galleryImages = document.querySelectorAll('.gallery-img');
 
-      galleryImages.forEach(img => {
-        img.addEventListener('click', () => {
-          lightboxImg.src = img.src;
-          lightbox.classList.add('active');
-        });
-      });
-
-      lightbox.addEventListener('click', () => {
-        lightbox.classList.remove('active');
-        lightboxImg.src = '';
-      });
-
-      document.addEventListener('keydown', (e) => {
-        if (lightbox.classList.contains('active') && e.key === 'Escape') {
-          lightbox.classList.remove('active');
-          lightboxImg.src = '';
-        }
-      });
+  galleryImages.forEach(img => {
+    img.addEventListener('click', () => {
+      lightboxImg.src = img.src;
+      lightbox.classList.add('active');
     });
+  });
+
+  lightbox.addEventListener('click', () => {
+    lightbox.classList.remove('active');
+    lightboxImg.src = '';
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (lightbox.classList.contains('active') && e.key === 'Escape') {
+      lightbox.classList.remove('active');
+      lightboxImg.src = '';
+    }
+  });
+
+  const sections = document.querySelectorAll('.section');
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('fade-in');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, {
+    threshold: 0.1
+  });
+
+  sections.forEach(section => {
+    observer.observe(section);
+  });
+});


### PR DESCRIPTION
## Summary
- bring Hub of SENSES page layout in line with Vista page
- add image lightbox to hub detail
- animate sections of vista detail for a consistent feel
- rename selectors in Vista CSS for consistency

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c20ca20c4832aa24b084e53e72d2b