### PR TITLE
Fix gallery caption overlap in hub detail page

### DIFF
--- a/css/hub_detail.css
+++ b/css/hub_detail.css
@@ -56,7 +56,7 @@ h2 {
   font-size: 0.9rem;
   text-align: center;
   color: #aaa;
-  margin-top: -10px;
+  margin-top: 10px; /* avoid overlapping images */
 }
 
 .image-grid {


### PR DESCRIPTION
## Summary
- ensure captions sit below images in `hub_detail.html`

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c250f2d94832ab3da09651ad3e2c1