### PR TITLE
Improve work card facts readability and cache busting

### DIFF
--- a/css/portfolio.css
+++ b/css/portfolio.css
@@ -19,7 +19,11 @@
       margin: 0 auto;
     }
 
-.works-grid { display: grid; gap: 2rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.works-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
 
 @media (min-width: 1024px) {
   .works-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }

--- a/hub_detail.html
+++ b/hub_detail.html
@@ -5,8 +5,8 @@
   <title>HUB of SENSES | テイテンメイ</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="css/hub_detail.css">
+  <link rel="stylesheet" href="style.css?v=20250812">
+  <link rel="stylesheet" href="css/hub_detail.css?v=20250812">
 </head>
 <body>
 <section id="hub-of-senses" class="project project--hub" aria-labelledby="hub-title">
@@ -98,6 +98,6 @@
     </article>
   </section>
 </section>
-<script src="js/hub.js" defer></script>
+<script src="js/hub.js?v=20250812" defer></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -64,10 +64,10 @@
   display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: .5rem .75rem;
 }
 .work-card__facts > div {
-  background: #fff; border-radius: 8px; padding: .5rem .6rem;
+  background: #fff; color: #111; border-radius: 8px; padding: .5rem .6rem;
 }
-.work-card__facts dt { font-weight: 700; font-size: .85rem; margin: 0 0 .15rem; }
-.work-card__facts dd { margin: 0; font-size: .95rem; }
+.work-card__facts dt { font-weight: 700; font-size: .9rem; margin: 0 0 .15rem; }
+.work-card__facts dd { margin: 0; font-size: 1rem; }
 
 .work-card__cta {
   padding: 0 .9rem .9rem;


### PR DESCRIPTION
## Summary
- Ensure work card fact tags use dark text with consistent font sizing
- Bust cached assets on hub detail page by appending version query parameters
- Clarify works grid layout with responsive column rules

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ae94159b0832a9e6613201466cb60