### PR TITLE
Refine hub detail assets and portfolio card styling

### DIFF
--- a/css/portfolio.css
+++ b/css/portfolio.css
@@ -64,3 +64,30 @@
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
   z-index: 10;
 }
+
+/* === Overrides for work cards on portfolio page === */
+/* Show full text for summary items (課題/着眼/成果) */
+.work-card__summary li {
+  display: block;
+  -webkit-line-clamp: unset;
+  -webkit-box-orient: unset;
+  overflow: visible;
+  text-overflow: unset;
+  white-space: normal;
+}
+
+/* Wider info tags with multiline support */
+.work-card__facts {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+/* Larger thumbnails with rounded corners */
+.work-card__media {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.work-card__media img {
+  aspect-ratio: 4/3;
+  border-radius: 0;
+}

--- a/hub_detail.html
+++ b/hub_detail.html
@@ -7,6 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css?v=20250812">
   <link rel="stylesheet" href="css/hub_detail.css?v=20250812">
+  <script defer src="js/hub.js?v=20250812"></script>
 </head>
 <body>
 <section id="hub-of-senses" class="project project--hub" aria-labelledby="hub-title">
@@ -98,6 +99,5 @@
     </article>
   </section>
 </section>
-<script src="js/hub.js?v=20250812" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load `hub_detail.css` and `hub.js` from the head of the hub detail page
- Show full challenge/approach/outcome text and widen fact tags on portfolio cards
- Enlarge portfolio thumbnails with rounded corners and overflow handling

## Testing
- `python -m http.server 8000 &`
- `curl -s http://localhost:8000/hub_detail.html | head -n 20`
- `curl -s http://localhost:8000/css/portfolio.css | tail -n 40`


------
https://chatgpt.com/codex/tasks/task_e_689aefa2c570832a86a4ed9b045e79ab