### PR TITLE
fix: load CSS and JS on HUB of SENSES page

### DIFF
--- a/hub_detail.html
+++ b/hub_detail.html
@@ -5,9 +5,9 @@
   <title>HUB of SENSES | テイテンメイ</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20250812">
-  <link rel="stylesheet" href="css/hub_detail.css?v=20250812">
-  <script defer src="js/hub.js?v=20250812"></script>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="css/hub_detail.css">
+  <script defer src="js/hub.js"></script>
 </head>
 <body>
 <section id="hub-of-senses" class="project project--hub" aria-labelledby="hub-title">


### PR DESCRIPTION
## Summary
- Remove cache-busting query strings so HUB of SENSES detail page loads shared styles and script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af0dfc204832aad31f0d407800304